### PR TITLE
Workaround go test -file

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -67,11 +67,6 @@
       (file-truename (or (locate-dominating-file filename "Makefile")
                          "./")))))
 
-(defun go-test-get-current-file (&optional file)
-  "Return the filename of the go test for `FILE'."
-  (let* ((file (or file (buffer-file-name))))
-    (f-long (f-filename file))))
-
 
 (defun go-test-get-current-test ()
   (let ((start (point))
@@ -86,6 +81,17 @@
         (search-forward "Test")
         (setq test-name (thing-at-point 'word))))
     test-name))
+
+
+(defun go-test-get-current-file-tests ()
+  "Generate regexp to match tests in the current buffer."
+  (save-excursion
+    (goto-char (point-min))
+    (let (tests)
+      (while (re-search-forward "^[[:space:]]*func[[:space:]]*\\(Test[^(]+\\)" nil t)
+        (let ((test (buffer-substring-no-properties (match-beginning 1) (match-end 1))))
+          (setq tests (append tests (list test)))))
+      (mapconcat 'identity tests "|"))))
 
 
 (defun go-test-arguments (args)
@@ -117,7 +123,7 @@
 (defun go-test-current-file ()
   "Launch go test on file."
   (interactive)
-  (let ((args (s-concat " -file=" (go-test-get-current-file))))
+  (let ((args (s-concat " -run='" (go-test-get-current-file-tests) "'")))
     (go-test-run args)))
 
 

--- a/test/go_test.go
+++ b/test/go_test.go
@@ -9,3 +9,7 @@ func TestFoo(t *testing.T) {
 func TestBar(t *testing.T) {
 	t.Log("logBar")
 }
+
+func Test_Baz(t *testing.T) {
+	t.Log("log_Baz")
+}

--- a/test/gotest-test.el
+++ b/test/gotest-test.el
@@ -40,12 +40,6 @@
 (defun go-test-command (&rest arg)
   (apply 's-concat "go test " arg))
 
-;; Files
-
-(ert-deftest test-go-test-get-current-file ()
-  (with-current-buffer (find-file-noselect testsuite-buffer-name)
-    (should (string= testsuite-buffer-name
-                     (go-test-get-current-file "go_test.go")))))
 
 ;; Arguments
 
@@ -65,6 +59,10 @@
     (save-excursion
       (re-search-forward "logFoo")
       (should (string= "TestFoo" (go-test-get-current-test))))))
+
+(ert-deftest test-go-test-get-current-file-tests ()
+  (with-current-buffer (find-file-noselect testsuite-buffer-name)
+    (should (string= "TestFoo|TestBar|Test_Baz" (go-test-get-current-file-tests)))))
 
 (provide 'gotest-test)
 ;;; gotest-test.el ends here


### PR DESCRIPTION
While 'go test' has a '-file' argument, it isn't actually supported.
See the source for src/cmd/go/test.go:
  "testFiles        []string   // -file flag(s)  TODO: not respected"

Workaround this by generating a regex for tests in the current file
and pass to 'go test' via the '-run' flag.
