### PR TITLE
Add go-run function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # gotest.el
 
-Manage the [GO](http://golang.org) tests from Emacs.
-
-## Deprecated
-
-See [Cerbere](https://github.com/nlamirault/cerbere)
+Run [Go](http://golang.org) tests and programs from Emacs.
 
 ## Installation
 
 The recommended way to install ``gotest.el`` is via [MELPA](http://melpa.milkbox.net/):
 
     M-x package-install gotest.el
+
+Or [el-get](http://tapoueh.org/emacs/el-get.html):
+
+    M-x el-get-install go-test
 
 or [Cask](https://github.com/cask/cask):
 
@@ -19,17 +19,53 @@ or [Cask](https://github.com/cask/cask):
 
 ## Usage
 
-### Available commands
+The following interactive commands can be run via <kbd>M-x</kbd> or
+bound to a key of your choice.
 
-2 functions are available :
-* `go-test-current-test`: launch unit tests for the current test
-* `go-test-current-file`: launch unit tests for the current file
+All `go-test-*` functions can optionally configure the buffer-local
+`go-test-args` variable to pass additional arguments.  Or, by using
+a prefix command, you will be prompted for arguments.  For example:
+<kbd>C-u M-x go-test-current-test</kbd>.
+
+When using the `'_` prefix arg with any of the `go-test-*` or `go-run`
+functions, the most recent arguments from history will be used without
+prompting.  For example: <kbd>M-- M-x go-run</kbd>.
+
+### go-test-current-test
+
+Launch unit tests for the current test.
+
+### go-test-current-file
+
+Launch unit tests for the current file.
+
+### go-test-current-project
+
+Launch unit tests for the current project.
+
+### go-run
+
+Launch program via `go run`.  Optionally configure the buffer-local
+`go-test-args` variable to pass additional arguments.  Or, by using
+a prefix command, you will be prompted for arguments.  For example:
+<kbd>C-u M-x go-run</kbd>.
+
+Be sure to make use of minibuffer history (<kbd>C-r</kbd>) to recall
+recent arguments to `go run`.  And remember that the <kbd>M--</kbd>
+prefix can be used in combination with your `go run` key binding to
+use the most recent arguments without prompting.  The go file is
+included in history, so you can `go-run` from history regardless of
+which buffer you are currently visiting.
+
+### Example key bindings
 
 You can create some key bindings with these commands:
 
 ```lisp
 (define-key go-mode-map (kbd "C-x f") 'go-test-current-file)
 (define-key go-mode-map (kbd "C-x t") 'go-test-current-test)
+(define-key go-mode-map (kbd "C-x p") 'go-test-current-project)
+(define-key go-mode-map (kbd "C-x x") 'go-run)
 ```
 
 ## Development

--- a/test/gotest-test.el
+++ b/test/gotest-test.el
@@ -40,6 +40,9 @@
 (defun go-test-command (&rest arg)
   (apply 's-concat "go test " arg))
 
+(defun go-run-command (&rest arg)
+  (apply 's-concat "go run " arg))
+
 
 ;; Arguments
 
@@ -47,10 +50,38 @@
   (should (string= (go-test-command)
 		   (go-test-get-program (go-test-arguments "")))))
 
+(ert-deftest test-go-test-get-program-with-args ()
+  (let ((go-test-args "-race"))
+    (should (string= (go-test-command " -race")
+                     (go-test-get-program (go-test-arguments ""))))))
+
 (ert-deftest test-go-test-add-verbose-argument ()
   (let ((go-test-verbose t))
     (should (string= (go-test-command " -v")
-		     (go-test-get-program (go-test-arguments ""))))))
+		     (go-test-get-program (go-test-arguments ""))))
+    (let ((go-test-args "-race"))
+      (should (string= (go-test-command " -v -race")
+                       (go-test-get-program (go-test-arguments "")))))))
+
+(ert-deftest test-go-run-command-without-args ()
+  (with-current-buffer (find-file-noselect testsuite-buffer-name)
+    (should (string= (go-run-command testsuite-buffer-name)
+                     (go-run-get-program (go-run-arguments))))))
+
+(ert-deftest test-go-run-command-with-args ()
+  (with-current-buffer (find-file-noselect testsuite-buffer-name)
+    (let ((go-run-args "-foo -bar=x"))
+      (should (string= (go-run-command (s-concat testsuite-buffer-name " -foo -bar=x"))
+                      (go-run-get-program (go-run-arguments)))))))
+
+(ert-deftest test-go-run-command-with-prefix ()
+  (with-current-buffer (find-file-noselect testsuite-buffer-name)
+    (let ((current-prefix-arg '-)
+          (go-run-args "-baz")
+          (go-run-history (mapcar (lambda (arg) (s-concat buffer-file-name " " arg))
+                                  '("-foo" "-bar" "-biz"))))
+      (should (string= (go-run-command (s-concat testsuite-buffer-name " -foo"))
+                       (go-run-get-program (go-run-arguments)))))))
 
 ;; Find
 


### PR DESCRIPTION
The interactive go-test-\* and go-run functions can provide additional
arguments with buffer-local go-{test,run}-args variables.  And arguments
can be provided interactively when given a prefix command.
