### PR TITLE
Add support for github.com/stretchr/testify/suite

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -172,7 +172,9 @@ For example, if the current buffer is `foo.go', the buffer for
                           (format "%s%s%s"
                                   go-test-regexp-prefix test-prefix
                                   go-test-regexp-suffix) nil t))
-        (match-string-no-properties 2)
+        (if (> (length (match-string-no-properties 1)) 0)
+            (concat "Test" (s-replace ")" "" (cadr (s-split "*" (match-string-no-properties 1)))))
+            (match-string-no-properties 2))
       (error "Unable to find a test"))))
 
 

--- a/test/go_test.go
+++ b/test/go_test.go
@@ -22,6 +22,6 @@ type Suite struct {
 	suite.Suite
 }
 
-func (s *Suite) TestSuite() {
+func (s *Suite) TestIndividualTest() {
 	s.T().Log("logSuite")
 }

--- a/test/go_test.go
+++ b/test/go_test.go
@@ -1,6 +1,10 @@
 package test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
 
 func TestFoo(t *testing.T) {
 	t.Log("logFoo")
@@ -12,4 +16,12 @@ func TestBar(t *testing.T) {
 
 func Test_Baz(t *testing.T) {
 	t.Log("log_Baz")
+}
+
+type Suite struct {
+	suite.Suite
+}
+
+func (s *Suite) TestSuite() {
+	s.T().Log("logSuite")
 }

--- a/test/gotest-test.el
+++ b/test/gotest-test.el
@@ -110,6 +110,14 @@
        (re-search-forward "logFoo")
        (should (string= "TestFoo" (go-test-get-current-test)))))))
 
+(ert-deftest test-go-test-get-current-test-when-suite-test ()
+  :tags '(find)
+  (with-test-sandbox
+   (with-current-buffer (find-file-noselect testsuite-buffer-name)
+     (save-excursion
+       (re-search-forward "logSuite")
+       (should (string= "TestSuite" (go-test-get-current-test)))))))
+
 (ert-deftest test-go-test-get-current-file-tests ()
   :tags '(find)
   (with-test-sandbox


### PR DESCRIPTION
Suite tests need special handling because they are acutally methods and
not top level functions. This commit also refactors
go-test-get-current-test to use regular expression groups. Closes #17.