### PR TITLE
Load cl-lib.el instead of cl.el

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -32,7 +32,7 @@
 
 (require 's)
 (require 'f)
-(require 'cl)
+(require 'cl-lib)
 (require 'go-mode)
 
 


### PR DESCRIPTION
Because this package uses cl-lib macro(cl-loop), not cl.el.

cl-lib is bundled since Emacs 24.3. And loading cl.el at runtime causes byte-compile warning.