### PR TITLE
Fix gb project detection

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -45,7 +45,7 @@
   :type 'boolean
   :group 'gotest)
 
-(defcustom gb-command "gb"
+(defcustom go-test-gb-command "gb"
   "The 'gb' command.
 A project based build tool for the Go programming language.
 See https://getgb.io."
@@ -206,7 +206,7 @@ When `ENV' concatenate before command."
 (defun go-test--gb-get-program (args)
   "Return the command to launch unit test using GB..
 `ARGS' corresponds to go command line arguments."
-  (s-concat gb-command " test " args))
+  (s-concat go-test-gb-command " test " args))
 
 
 (defun go-test--get-arguments (defaults history)
@@ -391,11 +391,12 @@ For example, if the current buffer is `foo.go', the buffer for
 
 (defun go-test--is-gb-project ()
   "Check if project use GB or not."
-  (let* ((root-dir (go-test--get-root-directory))
-         (vendor-dir (s-concat root-dir "vendor"))
-         (manifest (s-concat vendor-dir "/manifest")))
-    (and (f-dir? vendor-dir)
-         (f-exists? manifest))))
+  (let* ((go-test-gb-command (executable-find go-test-gb-command))
+         (default-directory (if go-test-gb-command (go-test--get-root-directory))))
+    (and go-test-gb-command
+         default-directory
+         (f-dir? "src")
+         (f-exists? "vendor/manifest"))))
 
 (defun go-test--cleanup (buffer)
   "Clean up the old go-test process BUFFER when a similar process is run."

--- a/test/gotest-test.el
+++ b/test/gotest-test.el
@@ -106,6 +106,23 @@
                          (s-concat testsuite-buffer-name " -foo"))
                         (go-test--go-run-get-program (go-test--go-run-arguments))))))))
 
+(ert-deftest test-go-test--is-gb-project ()
+  :tags '(arguments)
+  (with-test-sandbox
+   (let ((go-test-gb-command "a-program-name-that-does-not-exist"))
+     (should (null (go-test--is-gb-project))))
+   (let ((go-test-gb-command "go"))
+     (should (null (go-test--is-gb-project))))
+   (let ((go-test-gb-command "go")
+         (default-directory (expand-file-name "test/.cask/gb-fake-project")))
+     (make-directory "src" t)
+     (make-directory "vendor" t)
+     (with-temp-buffer
+       (write-file "Makefile")
+       (write-file "vendor/manifest"))
+     (with-current-buffer (find-file-noselect "Makefile")
+       (should (go-test--is-gb-project))))))
+
 ;; Find
 
 (ert-deftest test-go-test-get-current-test ()

--- a/test/gotest-version-test.el
+++ b/test/gotest-version-test.el
@@ -24,9 +24,9 @@
 
 (require 'test-helper)
 
-(ert-deftest phpunit-mode-library-version ()
+(ert-deftest test-go-test-library-version ()
   :expected-result (if (executable-find "cask") :passed :failed)
-  (let* ((cask-version (car (process-lines "cask" "version"))))
+  (let* ((cask-version (car (last (process-lines "cask" "version")))))
     (message "gotest.el Cask version: %s" cask-version)
     (should (string= "0.11.0" cask-version))))
 


### PR DESCRIPTION
- Add check for project "src" directory

- Assume not a gb project if go-test-gb-command is not found in
  exec-path

- Add 'go-test-' prefix to gb-command

- Ignore cask warnings in version test