### PR TITLE
Add support for compilation with comint-mode enabled

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -219,14 +219,17 @@ When `ENV' concatenate before command."
   "Get optional arguments for go test or go run.
 DEFAULTS will be used when there is no prefix argument.
 When a prefix argument of '- is given, use the most recent HISTORY item.
-When any other prefix argument is given, prompt for arguments using HISTORY."
-  (if current-prefix-arg
-      (if (equal current-prefix-arg '-)
-          (car (symbol-value history))
-        (let* ((name (nth 1 (s-split "-" (symbol-name history))))
-               (prompt (s-concat "go " name " args: ")))
-          (read-shell-command prompt defaults history)))
-    defaults))
+When single prefix argument is given, prompt for arguments using HISTORY.
+When double prefix argument is given, run command in compilation buffer with
+`comint-mode' enabled.
+When triple prefix argument is given, prompt for arguments using HISTORY and
+run command in compilation buffer `comint-mode' enabled."
+  (pcase current-prefix-arg
+    (`nil defaults)
+    ((or `- `(16)) (car (symbol-value history)))
+    ((or `(4) `(64)) (let* ((name (nth 1 (s-split "-" (symbol-name history))))
+                            (prompt (s-concat "go " name " args: ")))
+                       (read-shell-command prompt defaults history)))))
 
 
 (defun go-test--get-root-directory()
@@ -531,11 +534,13 @@ For example, if the current buffer is `foo.go', the buffer for
 
 
 ;;;###autoload
-(defun go-run ()
+(defun go-run (&optional args)
   "Launch go run on current buffer file."
   (interactive)
   ;;(add-hook 'compilation-start-hook 'go-test-compilation-hook)
-  (compile (go-test--go-run-get-program (go-test--go-run-arguments)))
+  (compile (go-test--go-run-get-program (go-test--go-run-arguments))
+           (pcase current-prefix-arg
+             ((or `(16) `(64)) t)))
   ;;(remove-hook 'compilation-start-hook 'go-test-compilation-hook))
   )
 


### PR DESCRIPTION
Sometimes I need to do `M-x go-run` but my program accepts user input,
since compilation mode is not complete shell it doesn't allow me to
write an input. I've searched and found that `comint-mode` enabled in
compilation buffer could help me. See http://endlessparentheses.com/provide-input-to-the-compilation-buffer.html.
This is my implementation of this feature. I hope it doesn't break your
API.

`C-u M-x go-run` - prompts for arguments using history
`C-u C-u M-x go-run` - run with `comint-mode` enabled
`C-u C-u C-u M-x go-run` - prompts for arguments using history and run with `comint-mode` enabled