### PR TITLE
Pass . as the package name in current-{test,file}

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -192,7 +192,7 @@ looked up in `go-testcompilation-error-regexp-alist-alist'.
 
 See also: `compilation-error-regexp-alist'."
   :type '(repeat (choice (symbol :tag "Predefined symbol")
-			 (sexp :tag "Error specification")))
+                         (sexp :tag "Error specification")))
   :group 'gotest)
 
 
@@ -458,8 +458,8 @@ For example, if the current buffer is `foo.go', the buffer for
                                              test-suite test-name) "")))
       (when test-name
         (if (go-test--is-gb-project)
-            (go-test--gb-start (s-concat "-test.v=true -test.run=" test-name "\\$"))
-          (go-test--go-test (s-concat test-flag test-name additional-arguments "\\$")))))))
+            (go-test--gb-start (s-concat "-test.v=true -test.run=" test-name "\\$ ."))
+          (go-test--go-test (s-concat test-flag test-name additional-arguments "\\$ .")))))))
 
 
 ;;;###autoload
@@ -469,7 +469,7 @@ For example, if the current buffer is `foo.go', the buffer for
   (let ((data (go-test--get-current-file-testing-data)))
     (if (go-test--is-gb-project)
         (go-test--gb-start (s-concat "-test.v=true -test.run='" data "'"))
-      (go-test--go-test (s-concat "-run='" data "'")))))
+      (go-test--go-test (s-concat "-run='" data "' .")))))
 
 
 ;;;###autoload


### PR DESCRIPTION
# What's this PR do?

This ensures that whenever gotest.el invokes `go test`, the package `.` is passed on the command line. 

# Why?

Apparently, the test runner turns on verbosity when it's not given a package to test, so it ignores the `go-test-verbose` flag.

# Notes

I've run gotest.el with this for a year now (forked off version 0.7! Phew!) - hope this is acceptable (-: