### PR TITLE
Re-use the test output buffer if it is shown

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -415,11 +415,12 @@ For example, if the current buffer is `foo.go', the buffer for
 
 (defun go-test--cleanup (buffer)
   "Clean up the old go-test process BUFFER when a similar process is run."
-  (when (get-buffer-process (get-buffer buffer))
-    (delete-process buffer))
   (when (get-buffer buffer)
-    (kill-buffer buffer)))
-
+    (when (get-buffer-process (get-buffer buffer))
+      (delete-process buffer))
+    (with-current-buffer buffer
+      (setq buffer-read-only nil)
+      (erase-buffer))))
 
 (defun go-test--gb-start (args)
   "Start the GB test command using `ARGS'."


### PR DESCRIPTION
# What does this PR do?

This change only erases the *Go Test* buffer prior to a run, as opposed
to killing it. This ensures that window/frame arrangements can be made
to show the output buffer in a single place reliably.

# Why?

I think this should take care of #40 - I have had the same issue. With this change, I can make a `popwin` configuration like this:
``` elisp
(push '(go-test-mode :width 80 :position right :noselect t) popwin:special-display-config)
```
allows me to re-use the buffer and not split windows all the time (in fact, if the test buffer is open in a frame on my second display, it stays there - very convenient!)