### PR TITLE
Fixed test profile multiple packages issue

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -527,7 +527,7 @@ For example, if the current buffer is `foo.go', the buffer for
     (let ((args (s-concat
                  "--coverprofile="
                  (expand-file-name
-                  (read-file-name "Coverage file" nil "cover.out")) " ./...")))
+                  (read-file-name "Coverage file" nil "cover.out")) " ./.")))
       (go-test--go-test args))))
 
 


### PR DESCRIPTION
`go test --coverprofile cover.out ./...` =>

cannot use test profile flag with multiple packages

Fixed it with `./.`