### PR TITLE
No longer provide a feature in test-helper.el

### DIFF
--- a/test/gotest-version-test.el
+++ b/test/gotest-version-test.el
@@ -22,8 +22,6 @@
 ;;; Code:
 
 
-(require 'test-helper)
-
 (ert-deftest test-go-test-library-version ()
   :expected-result (if (executable-find "cask") :passed :failed)
   (let* ((cask-version (car (last (process-lines "cask" "version")))))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -89,5 +89,4 @@
          ;; (error
          ;;  (message (ansi-red "[gotest] Error during unit tests : %s" ex))))))
 
-(provide 'test-helper)
 ;;; test-helper.el ends here


### PR DESCRIPTION
**Note that one of the tests fails, but it is the same test that
also fails without these changes.**

The file isn't a library intended to be loaded with `require`.
Instead `ert-runner` loads it using `load`.  Other packages that
use `ert-runner` also come with a file named test-helper.el and
unfortunately many of those also provide `test-helper`, which
leads to conflicts.