### PR TITLE
Raise a friendly error if no test file exists

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -249,6 +249,8 @@ For example, if the current buffer is `foo.go', the buffer for
       (current-buffer)
     (let ((ff-always-try-to-create nil))
       (let ((filename (ff-other-file-name)))
+        (unless filename
+          (user-error (format "Unable to find a test file for file %s" buffer-file-name)))
         (message "File :%s" filename)
         (find-file-noselect filename)))))
 

--- a/test/gotest-test.el
+++ b/test/gotest-test.el
@@ -42,6 +42,10 @@
   (f-join go-test-testsuite-dir "go_test.go")
   "File name for testing.")
 
+(defconst testsuite-file-with-no-test-file-name
+  (f-join go-test-testsuite-dir "idonothavetests.go")
+  "Name of a file that does not have corresponding _test.go file")
+
 ;; (load (expand-file-name "../gotest" testsuite-dir) nil :no-message)
 ;; (load (expand-file-name "test-helper.el" testsuite-dir) nil :no-message)
 
@@ -196,6 +200,13 @@
      (save-excursion
        (re-search-forward "Example A")
        (should (string= "ExampleA" (go-test--get-current-test)))))))
+
+(ert-deftest test-go-test-get-current-buffer ()
+  :tags '(current)
+  (with-test-sandbox
+   (let ((buffer-file-name testsuite-file-with-no-test-file-name))
+     (should-error (go-test--get-current-buffer)
+                   :type 'user-error))))
 
 ;; Error Regexp
 


### PR DESCRIPTION
If go-test-current-file is called from a go file with no corresponding
_test.go file, it will fail with (wrong-type-argument stringp nil).

Catch this before the lisp error is raised and output a friendlier message.