### PR TITLE
add missing $ after test name

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -462,7 +462,7 @@ For example, if the current buffer is `foo.go', the buffer for
       (when test-name
         (if (go-test--is-gb-project)
             (go-test--gb-start (s-concat "-test.v=true -test.run=" test-name "\\$ ."))
-          (go-test--go-test (s-concat test-flag test-name additional-arguments "\\$ .")))))))
+          (go-test--go-test (s-concat test-flag test-name "\\$" additional-arguments "\\$ .")))))))
 
 
 ;;;###autoload


### PR DESCRIPTION
Otherwise running go-test-current-test on Foo can result in running
both Foo and FooBar