### PR TITLE
Resolves #63 - interpret C-u number as count parameter

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -222,9 +222,11 @@ When single prefix argument is given, prompt for arguments using HISTORY.
 When double prefix argument is given, run command in compilation buffer with
 `comint-mode' enabled.
 When triple prefix argument is given, prompt for arguments using HISTORY and
-run command in compilation buffer `comint-mode' enabled."
+run command in compilation buffer `comint-mode' enabled.
+When a numeric prefix argument is provided, it is used as the -count flag."
   (pcase current-prefix-arg
     (`nil defaults)
+    ((pred integerp) (s-concat (format "-count=%d " current-prefix-arg) defaults))
     ((or `- `(16)) (car (symbol-value history)))
     ((or `(4) `(64)) (let* ((name (nth 1 (s-split "-" (symbol-name history))))
                             (prompt (s-concat "go " name " args: ")))

--- a/test/gotest-test.el
+++ b/test/gotest-test.el
@@ -106,6 +106,16 @@
                          (s-concat testsuite-buffer-name " -foo"))
                         (go-test--go-run-get-program (go-test--go-run-arguments))))))))
 
+(ert-deftest test-go-run-command-with-numeric-prefix ()
+  :tags '(arguments)
+  (with-test-sandbox
+   (with-current-buffer (find-file-noselect testsuite-buffer-name)
+     (let ((current-prefix-arg '10)
+           (go-run-args "-foo=x"))
+       (should (string= (go-run-command
+                         (s-concat "-count=10 " testsuite-buffer-name " -foo=x"))
+                        (go-test--go-run-get-program (go-test--go-run-arguments))))))))
+
 (ert-deftest test-go-test--is-gb-project ()
   :tags '(arguments)
   (with-test-sandbox


### PR DESCRIPTION
Provide a shorthand for passing the -count flag to go test.

For example C-u 1 M-x go-test-current-file will pass -count=1 as the first
argument to `go test`. This is useful because, as of go 1.10, the idiomatic
way to dismiss test caching is to pass -count=1.