### PR TITLE
Resolves #62 - ensure compilation-sentinel is invoked

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -150,6 +150,7 @@ arguments in that order.")
 
 (defun go-test--finished-sentinel (process event)
   "Execute after PROCESS return and EVENT is 'finished'."
+  (compilation-sentinel process event)
   (when (equal event "finished\n")
     (message "Go Test finished.")))
 


### PR DESCRIPTION
Because we were clobbering the process sentinel defined in compile.el, we
never correctly cleaned up after process exit, including for example
removing the "Compiling" text in the mode line. (We were just leaking the
processes into compilation-in-progress.)

This commit ensures that compilation-sentinel is still invoked.

Maybe a nicer way to do this is to get the existing `process-sentinel` value
and wrap around that, rather than naming the compilation-sentinel directly,
but it adds a perhaps needless amount of complexity for what we actually
want to do here.