### PR TITLE
Handle non-existing test buffers gracefully

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -250,10 +250,10 @@ For example, if the current buffer is `foo.go', the buffer for
 `foo_test.go' is returned."
   (if (string-match "_test\.go$" buffer-file-name)
       (current-buffer)
-    (let ((ff-always-try-to-create nil))
-      (let ((filename (ff-other-file-name)))
-        (message "File :%s" filename)
-        (find-file-noselect filename)))))
+    (let ((ff-always-try-to-create nil)
+	  (filename (ff-other-file-name)))
+      (when filename
+	(find-file-noselect filename)))))
 
 
 (defun go-test--get-current-data (prefix)
@@ -309,19 +309,21 @@ For example, if the current buffer is `foo.go', the buffer for
 (defun go-test--get-current-file-data (prefix)
   "Generate regexp to match test, benchmark or example the current buffer.
 `PREFIX' defines token to place cursor."
-  (with-current-buffer (go-test--get-current-buffer)
-    (save-excursion
-      (goto-char (point-min))
-      (if (string-match "\.go$" buffer-file-name)
-          (let ((regex
-                 (s-concat "^[[:space:]]*func[[:space:]]*\\(" prefix "[^(]+\\)"))
-                result)
-            (while
-                (re-search-forward regex nil t)
-              (let ((data (buffer-substring-no-properties
-                           (match-beginning 1) (match-end 1))))
-                (setq result (append result (list data)))))
-            (mapconcat 'identity result "|"))))))
+  (let ((buffer (go-test--get-current-buffer)))
+    (when buffer
+      (with-current-buffer buffer
+	(save-excursion
+	  (goto-char (point-min))
+	  (when (string-match "\.go$" buffer-file-name)
+            (let ((regex
+                   (s-concat "^[[:space:]]*func[[:space:]]*\\(" prefix "[^(]+\\)"))
+                  result)
+	      (while
+                  (re-search-forward regex nil t)
+		(let ((data (buffer-substring-no-properties
+                             (match-beginning 1) (match-end 1))))
+                  (setq result (append result (list data)))))
+	      (mapconcat 'identity result "|"))))))))
 
 
 (defun go-test--get-current-file-tests ()


### PR DESCRIPTION
Fixes this `go-test-current-file` error when no corresponding test file exists:

```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  expand-file-name(nil)
  find-file-noselect(nil)
  (let ((filename (ff-other-file-name))) (message "File :%s" filename) (find-file-noselect filename))
  (let ((ff-always-try-to-create nil)) (let ((filename (ff-other-file-name))) (message "File :%s" filename) (find-file-noselect filename)))
  (if (string-match "_test.go$" buffer-file-name) (current-buffer) (let ((ff-always-try-to-create nil)) (let ((filename (ff-other-file-name))) (message "File :%s" filename) (find-file-noselect filename))))
  go-test--get-current-buffer()
  (set-buffer (go-test--get-current-buffer))
  (save-current-buffer (set-buffer (go-test--get-current-buffer)) (save-excursion (goto-char (point-min)) (if (string-match ".go$" buffer-file-name) (let ((regex (s-concat "^[[:space:]]*func[[:space:]]*\\(" prefix "[^(]+\\)")) result) (while (re-search-forward regex nil t) (let ((data (buffer-substring-no-properties (match-beginning 1) (match-end 1)))) (setq result (append result (list data))))) (mapconcat 'identity result "|")))))
  go-test--get-current-file-data("Test")
  go-test--get-current-file-tests()
  (let ((tests (go-test--get-current-file-tests)) (examples (go-test--get-current-file-examples))) (cond ((and (> (length tests) 0) (> (length examples) 0)) (s-concat tests "|" examples)) ((= (length tests) 0) examples) ((= (length examples) 0) tests)))
  go-test--get-current-file-testing-data()
  (let ((data (go-test--get-current-file-testing-data))) (if (go-test--is-gb-project) (go-test--gb-start (s-concat "-test.v=true -test.run='" data "'")) (go-test--go-test (s-concat "-run='" data "' ."))))
  go-test-current-file()
  funcall-interactively(go-test-current-file)
  call-interactively(go-test-current-file record nil)

```