### PR TITLE
resolves #67 -- use namespaced testify flag

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -458,7 +458,7 @@ For example, if the current buffer is `foo.go', the buffer for
   "Launch go test on the current test."
   (interactive)
   (cl-destructuring-bind (test-suite test-name) (go-test--get-current-test-info)
-    (let ((test-flag (if (> (length test-suite) 0) "-m " "-run "))
+    (let ((test-flag (if (> (length test-suite) 0) "-testify.m " "-run "))
           (additional-arguments (if go-test-additional-arguments-function
                                     (funcall go-test-additional-arguments-function
                                              test-suite test-name) "")))


### PR DESCRIPTION
Originally this was just `-m`, but was namespaced to `-testify.m` 2 years
ago, in https://github.com/stretchr/testify/commit/bfe70f3776f95c8c83debfde6ea754ab62a147d2

This commit updates the suite aware flag to use the namespaced version. This
will be a breaking change if you're using a testify from > 2 years ago, but
on the flip side, it's currently broken if you're using something more
recent than that!