### PR TITLE
Rerun current test with go-test-current-test-cache()

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ prompting.  For example: <kbd>M-- M-x go-run</kbd>.
 
 Launch unit tests for the current test.
 
+### go-test-current-test-cache
+
+Rerun the current test.
+
 ### go-test-current-file
 
 Launch unit tests and examples for the current file


### PR DESCRIPTION
Please, see the following ticket https://github.com/nlamirault/gotest.el/issues/72

## What is done
- [x] add a new variable `go-test--current-test-cache` to save the state of go-test--get-current-test-info
- [x] add a new function `go-test-current-test-cache`
- [x] refactor `go-test-current-test`
- [x] update README.md