### PR TITLE
Fix order of commandline arguments concatenation

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -478,7 +478,7 @@ For example, if the current buffer is `foo.go', the buffer for
         (when test-name
           (if (go-test--is-gb-project)
               (go-test--gb-start (s-concat "-test.v=true -test.run=" test-name "\\$ ."))
-            (go-test--go-test (s-concat test-flag test-name additional-arguments "\\$ ."))))))))
+            (go-test--go-test (s-concat test-flag test-name "\\$ . " additional-arguments))))))))
 
 
 ;;;###autoload


### PR DESCRIPTION
Additional arguments should be added as the last commandline
arguments. Currently it adds them between test name and `\$`.

For example, if additional arguments are set to `-count=1` command
line will be creates as follows:

```
go test -run TestSomeTest-count=1 \$ . -v
```

After the fix:

```
go test -run TestSomeTest\$ . -count=1  -v
```