### PR TITLE
Add command of rerun the previous test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Launch go benchmark on current file
 
 Launch go benchmark on current project
 
+### go-test-rerun-test
+
+Rerun the previous test.
+
 ### go-run
 
 Launch program via `go run`.  Optionally configure the buffer-local


### PR DESCRIPTION
`go-test-current-test-cache` cannot be executed if the directory is changed. Therefore, I added a command that can be executed even if the directory is changed.

ref  #72