### PR TITLE
Put any extra arguments from go-test-args before the test name

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -361,10 +361,10 @@ For example, if the current buffer is `foo.go', the buffer for
 (defun go-test--arguments (args)
   "Make the go test command argurments using `ARGS'."
   (let ((opts args))
-    (when go-test-verbose
-      (setq opts (s-concat opts " -v")))
     (when go-test-args
-      (setq opts (s-concat opts " " go-test-args)))
+      (setq opts (s-concat go-test-args " " opts)))
+    (when go-test-verbose
+      (setq opts (s-concat "-v " opts)))
     (go-test--get-arguments opts 'go-test-history)))
 
 


### PR DESCRIPTION
This fixes the order of arguments.  When running a single testify test with `go-test-args` set to "-race" to enable the race checker, I was getting the following command:

``` sh
go test -testify.m TestRelationsRace\$ . -race
```

This caused the -race flag to be ignored; it is supposed to be before the package name.  This PR changes the order of the arguments so this command is now generated as:

```sh
go test -race -testify.m TestRelationsRace\$ . 
```

which works properly. 